### PR TITLE
Field and value being passed in URL param need to be URL encoded #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.2.4 (draft)
 
 * Add `id` and `class` to nav and sidenav items
+* URL encode field name and value in URL paths for API request
 
 ## 1.2.3
 

--- a/kyte-source.js
+++ b/kyte-source.js
@@ -128,10 +128,10 @@ class Kyte {
 				let identity = encodeURIComponent(btoa(obj.access_key + '%' + obj.sessionToken + '%' + time.toUTCString() + '%' + obj.account_number));
 				var apiURL = obj.url + '/' + model;
 				if (field) {
-					apiURL += '/' + field;
+					apiURL += '/' + encodeURIComponent(field);
 				}
 				if (value) {
-					apiURL += '/' + value;
+					apiURL += '/' + encodeURIComponent(value);
 				}
 
 				var encdata = '';


### PR DESCRIPTION
### Changes Proposed in This PR
URL encode field name and value in URL path for API request

### Linked Issues
Issue #4 
Issue keyqcloud/kyte-php#29

### Implementation Details
Add `encodeURIComponent` for field name and value.

### Dependencies
n/a

### Testing Strategy
Confirm that field name and value are correctly encoded.

### Checklist Before Requesting Review
- [x] Changes are complete and tested.
- [x] Pull request targets the correct branch.
- [x] Code is consistent with the existing codebase.
- [x] Linter/static analysis passes.
- [x] Existing tests pass.
- [x] Documentation and changelog are updated.