### PR TITLE
ci(release-please): hide chore commits from release triggers

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,15 +12,15 @@
         { "type": "fix",      "section": "Bug Fixes" },
         { "type": "perf",     "section": "Performance Improvements" },
         { "type": "revert",   "section": "Reverts" },
-        { "type": "docs",     "section": "Documentation" },
-        { "type": "test",     "section": "Tests" },
-        { "type": "build",    "section": "Build System" },
-        { "type": "ci",       "section": "Continuous Integration" },
-        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
-        { "type": "style",    "section": "Styles",           "hidden": true },
-        { "type": "chore",    "section": "Miscellaneous",    "hidden": true }
+        { "type": "docs",     "section": "Documentation",       "hidden": true },
+        { "type": "test",     "section": "Tests",               "hidden": true },
+        { "type": "build",    "section": "Build System",        "hidden": true },
+        { "type": "ci",       "section": "Continuous Integration", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring",    "hidden": true },
+        { "type": "style",    "section": "Styles",              "hidden": true },
+        { "type": "chore",    "section": "Miscellaneous",       "hidden": true }
       ]
     }
   },
-  "bootstrap-sha": "daf350ed4a2687e102c01294cb350da323b6011c"
+  "bootstrap-sha": "48437a8e1c3bda415457b131ae9051f52b8f5e8a"
 }


### PR DESCRIPTION
## Summary

Closes the symptom from PR #28 — release-please opened a content-less v1.4.1 release PR immediately after the previous chore branch merged.

## Root cause

`release-please-config.json` listed `docs`, `test`, `build`, `ci` in `changelog-sections` without `hidden: true`. release-please interprets non-hidden types as **both** CHANGELOG sections **and** release triggers. The chore branch contained 4 ci/test commits → release-please saw a releasable change set → opened the v1.4.1 Release PR.

That v1.4.1 release would have shipped a bit-identical `kyte.js` (no source change in the chore branch). Just noise between v1.4.0 and the upcoming v2.0.0. PR #28 was closed unmerged.

## Fix

1. **Mark `docs`/`test`/`build`/`ci` as `hidden: true`.** Brings them in line with `refactor`/`style`/`chore` — invisible to release-please for both presentation and triggering.
2. **Bump `bootstrap-sha` to `48437a8`** (the merge commit from PR #27). Without this, release-please would re-walk the chore-branch commits on its next run and still propose a release even with `hidden: true` (since `hidden` controls display, not the "already considered" high-water mark).

This commit's own type is `ci(release-please):` — also hidden after the change lands — so merging this PR doesn't itself trigger another v1.4.1 proposal.

## Expected behavior after merge

- release-please runs on the master push
- It walks commits after `bootstrap-sha=48437a8`
- The only post-bootstrap commit is this one (`ci(release-please):` → hidden)
- No Release PR opens
- CHANGELOG and `.release-please-manifest.json` unchanged

Once verified, v2.0.0 ships via the existing manual `./release.sh 2.0.0` flow. v2.0.1+ goes through the release-please PR flow with only `feat:`/`fix:`/`perf:`/`revert:` commits triggering bumps.

## Test plan

- [ ] Test CI workflow green on this PR
- [ ] After merge: watch the release-please workflow run on master
- [ ] Confirm no new Release PR opens
- [ ] Confirm CHANGELOG unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)