### PR TITLE
ci: opt into Node.js 24 ahead of 2026-06-02 force-migration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '0 3 * * 0'
 
+# Opt into Node.js 24 ahead of the 2026-06-02 force-migration.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analyze:
     name: Analyze
@@ -48,7 +52,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,13 @@ on:
 permissions:
   contents: write   # needed for softprops/action-gh-release
 
+# GitHub force-migrates JavaScript actions to Node.js 24 on 2026-06-02.
+# Opting in early so the migration is a no-op for us; covers the actions
+# whose latest major (aws-actions/configure-aws-credentials@v4,
+# softprops/action-gh-release@v2) doesn't yet have a Node-24-native bump.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     name: Build, deploy, and release
@@ -26,7 +33,7 @@ jobs:
       uses: actions/checkout@v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '20'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 
+# GitHub force-migrates JavaScript actions to Node.js 24 on 2026-06-02.
+# Opting in early so the migration is a no-op for us.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Unit tests (Node ${{ matrix.node }})
@@ -23,7 +28,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up Node.js ${{ matrix.node }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node }}
         cache: 'npm'


### PR DESCRIPTION
## Summary

The v2.0.0 deploy surfaced a deprecation warning naming three actions still on Node 20:
- `actions/setup-node@v4`
- `aws-actions/configure-aws-credentials@v4`
- `softprops/action-gh-release@v2`

GitHub force-migrates JavaScript actions to Node.js 24 on **2026-06-02**. Two fixes belt-and-suspenders:

1. **Bump actions where a newer major exists.** `actions/setup-node` v4→v5 in `deploy.yml` and `test.yml`. Also bumped `actions/checkout@v4` → `@v5` in `codeql.yml` (the only workflow still on v4).

2. **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var** at the workflow level in all three workflows. Forces every JS action to Node 24 regardless of declared version. Covers `aws-actions/configure-aws-credentials@v4` and `softprops/action-gh-release@v2`, neither of which has a newer major yet.

Once both maintainers ship Node-24-native majors, we can drop the env var.

## Test plan

- [ ] Test CI green on this PR (test.yml will run on the new setup-node@v5)
- [ ] CodeQL green
- [ ] After merge, the next push doesn't show the Node 20 deprecation annotation
- [ ] After next tag (whenever that is), deploy.yml completes without annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)