### PR TITLE
build: keep runtime VERSION literal in sync with the release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,20 @@ jobs:
         VERSION="${{ steps.version.outputs.VERSION }}"
         YEAR=$(date +'%Y')
 
+        # Force the runtime VERSION literal to the tag. Single source of
+        # truth is the git tag (same as the copyright header below).
+        # release-please's x-release-please-version annotation keeps the
+        # committed source in sync; this is the belt-and-suspenders so the
+        # SHIPPED bundle can never drift from the tag even if that slips
+        # (which is exactly how v2.1.0 went out logging "2.0.2").
+        sed -i -E "s/(static VERSION *= *['\"])[0-9]+\.[0-9]+\.[0-9]+(['\"])/\1${VERSION}\2/" kyte-source.js
+        STAMPED=$(grep -oE "static VERSION *= *['\"][0-9.]+['\"]" kyte-source.js)
+        echo "Stamped: ${STAMPED}"
+        if ! echo "${STAMPED}" | grep -q "'${VERSION}'"; then
+          echo "::error::Failed to stamp VERSION literal to ${VERSION} (got: ${STAMPED})."
+          exit 1
+        fi
+
         # Two builds:
         #   kyte.js      — minified, with `//# sourceMappingURL=kyte.js.map`
         #                  appended by terser; pairs with kyte.js.map for

--- a/kyte-source.js
+++ b/kyte-source.js
@@ -16,8 +16,11 @@
  * ©2020-2023 KeyQ, Inc.
  **/
 class Kyte {
-	/** KyteJS Version # */
-	static VERSION = '2.0.2';
+	/** KyteJS Version # — kept in sync with the release by release-please
+	 *  (x-release-please-version annotation; see release-please-config.json
+	 *  extra-files). The deploy workflow also force-stamps this from the git
+	 *  tag at build time as a belt-and-suspenders. */
+	static VERSION = '2.1.0'; // x-release-please-version
 	/** **************** */
 
 	/**

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,9 @@
       "package-name": "kyte-api-js",
       "include-component-in-tag": false,
       "include-v-in-tag": true,
+      "extra-files": [
+        { "type": "generic", "path": "kyte-source.js" }
+      ],
       "changelog-sections": [
         { "type": "feat",     "section": "Features" },
         { "type": "fix",      "section": "Bug Fixes" },


### PR DESCRIPTION
## Problem
v2.1.0 shipped logging `Initialized KyteJS v2.0.2` — the `static VERSION` literal in `kyte-source.js` was never bumped. release-please updates `package.json` + the manifest but not the JS literal, and `deploy.yml` builds straight from source, so the stale literal rode to the CDN.

## Fix (three layers, defense in depth)
1. **`x-release-please-version` annotation** on the `VERSION` line + `extra-files` in `release-please-config.json` → release-please now bumps the literal in the release PR, keeping committed source correct.
2. **`deploy.yml` force-stamps** the literal from the git tag at build time (single source of truth = the tag, same as the copyright header already does) and **fails the build** if the stamp didn't take.
3. Bumped the current literal to `2.1.0` to match the live release.

Net: the shipped CDN bundle can never again report a version different from its tag.

## Note
This does **not** re-deploy the CDN. The live v2.1.0 file keeps logging "2.0.2" until the next tag push (or a manual re-push of v2.1.0, which would now stamp correctly). Cosmetic only — the code is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)