### PR TITLE
feat(table): send x-kyte-fields projection header from KyteTable (KYTE-#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.0
+
+### Feature: KyteTable column projection (KYTE-#190)
+
+`KyteTable` now sends an `x-kyte-fields` header listing the columns it displays, so a list read returns only those columns instead of every column (large `TEXT`/`BLOB` columns stay out of list payloads). The value is the same field list the table already builds from its `columnDefs` (dotted FK paths like `client.name` included) — a distinct header from `x-kyte-page-search-fields` because search ("which columns to match") and projection ("which columns to return") are different concerns. Requires kyte-php ≥ 4.16 (the server maps dotted FK paths to their base column and always adds `id` + FK ids back, so row actions and FK labels keep working). Fully backward compatible: an older server ignores the header.
+
 ## 2.1.0
 
 ### Feature: anonymous fall-through for JWT-mode public access (KYTE-#229)

--- a/kyte-source.js
+++ b/kyte-source.js
@@ -1501,6 +1501,13 @@ class KyteTable {
 		headers.push({'name':'x-kyte-page-idx','value': this.currentPage});
 		headers.push({'name':'x-kyte-page-search-value','value': this.searchValue ? btoa(encodeURIComponent(this.searchValue)) : ""});
 		headers.push({'name':'x-kyte-page-search-fields','value': fields.join(',')});
+		// Column projection (KYTE-#190): tell the server to return only the
+		// fields this table actually displays (dotted FK paths like
+		// `client.name` included — the server maps them to their base column).
+		// Same value as search-fields but a distinct header: search = which
+		// columns to match; projection = which columns to return. The server
+		// always adds id + FK ids back, so row actions and FK labels still work.
+		headers.push({'name':'x-kyte-fields','value': fields.join(',')});
 
 		if (this.sortColumn) {
 			headers.push({'name':'x-kyte-page-order-col','value': this.sortColumn});


### PR DESCRIPTION
The client half of the KYTE-#190 column-projection feature — makes it live end-to-end.

## What
`KyteTable._loadData` now sends an **`x-kyte-fields`** header (one line) listing the columns the table displays. The server then returns only those columns for the list read, keeping large `TEXT`/`BLOB` columns out of list payloads.

- The value is the **same field list KyteTable already builds** from `columnDefs` (`kyte-source.js:1491-1496`) — dotted FK paths like `client.name` included. **Zero new developer config.**
- Sent as a header **distinct** from `x-kyte-page-search-fields` (search = which columns to LIKE-match; projection = which columns to return).

## Server pairing
Requires kyte-php ≥ 4.16 (the generic `ModelController` projection wiring). The server maps dotted FK paths to their base column and always re-adds `id` + FK ids, so row actions, edit/delete, and FK labels keep working. **Backward compatible** — an older server ignores the header.

## Validation
- Vitest suite green (17 tests) — the source still loads/parses; `KyteTable` isn't in the unit harness (no DOM/jQuery mocks), so recommend a manual smoke on a real table before release.
- **Release (CDN) is a separate manual step** (this repo's `release.sh` → deploy ritual) — not triggered by this PR.

Refs #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)